### PR TITLE
Fix registration bug

### DIFF
--- a/app/apis/auth.py
+++ b/app/apis/auth.py
@@ -57,7 +57,7 @@ class Register(Resource):
 
         # Create user
         try:
-            user_id = user_resource.create_user(email, password, name, role)
+            user_id = user_resource.create_user(email, password, name, birthday, role)
         except Exception as e:
             # Handle duplicate key error from MongoDB unique index
             if "duplicate key" in str(e).lower() or "E11000" in str(e):


### PR DESCRIPTION
## Summary
- Fixed a bug in the registration endpoint where the `birthday` argument was missing from the `create_user()` call
- This caused `role` to be stored in the `birthday` field (due to positional argument shift) and `role` to always default to `"member"`, regardless of what the user selected

## Root Cause
In `app/apis/auth.py`, the call was:
user_resource.create_user(email, password, name, role)
